### PR TITLE
Deep get or else feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,21 @@ const clusterName = deepGet(cluster, 'up.149.label')
 const clusterName = cluster.up && cluster.up['149'] && cluster.up['149'].label
 ```
 
+We have another function to use with it, the `deepGetOrElse` comes with a isNothing check, so that if you are sure you'll need a fallback value you can put it already on the function and have no need to check it later
+```js
+const { deepGetOrElse } = require('deep-getter')
+
+// Let's revisit this piece of code
+const grayHex = product.details && product.details.specs && product.details.specs.color && product.details.specs.color.gray
+
+grayHex ? grayHex : '#444'
+
+// This is where deepGetOrElse really shines:
+deepGetOrElse(product, 'details.specs.color.gray', '#444')
+
+```
+And this is it, the fallback: `'#444'` will return if `product.details.specs.color.gray` is Nothing
+
 ## Docs
 You can access the docs at: [docs](https://github.com/patocinza/deep-gettertree/master/docs)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,10 @@ returns <a href="#Nothing">Nothing</a> if it is not possible to fetch the value<
 <dt><a href="#isNothing">isNothing</a> ⇒ <code>Boolean</code></dt>
 <dd><p>Checks if x is Nothing</p>
 </dd>
+<dt><a href="#deepGetOrElse">deepGetOrElse</a></dt>
+<dd><p>Access deep properties on object going through the given path
+If it would return a <a href="#Nothing">Nothing</a>, it returns <code>fallback</code> instead</p>
+</dd>
 </dl>
 
 ## Interfaces
@@ -55,4 +59,18 @@ Checks if x is Nothing
 | Param | Type | Description |
 | --- | --- | --- |
 | x | <code>\*</code> | Anything you want to test |
+
+<a name="deepGetOrElse"></a>
+
+## deepGetOrElse
+Access deep properties on object going through the given path
+If it would return a [Nothing](#Nothing), it returns `fallback` instead
+
+**Kind**: global variable  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| obj | <code>Object</code> | Object to be accessed |
+| path | <code>String</code> | Path to be accessed separated by . |
+| fallback | <code>\*</code> | the value to return if obj[path] is Nothing |
 

--- a/index.js
+++ b/index.js
@@ -27,6 +27,17 @@ module.exports = {
   deepGet: (obj, path) => path && path.split('.').reduce(get, obj),
 
   /**
+   * Access deep properties on object going through the given path
+   * If it would return a {@link Nothing}, it returns `fallback` instead
+   * @global
+   * @name deepGetOrElse
+   * @param { Object } obj Object to be accessed
+   * @param { String } path Path to be accessed separated by .
+   * @param { * } fallback the value to return if obj[path] is Nothing
+   */
+  deepGetOrElse: (obj, path, fallback) => isNothing(getAll(obj, path)) ? fallback : getAll(obj, path),
+
+  /**
    * Checks if x is Nothing
    * @global
    * @name isNothing

--- a/index.js
+++ b/index.js
@@ -43,6 +43,6 @@ const isNothing = (x) => x === Nothing
  * @param { String } path Path to be accessed separated by .
  * @param { * } fallback the value to return if obj[path] is Nothing
  */
-deepGetOrElse = (obj, path, fallback) => isNothing(deepGet(obj, path)) ? fallback : deepGet(obj, path)
+const deepGetOrElse = (obj, path, fallback) => isNothing(deepGet(obj, path)) ? fallback : deepGet(obj, path)
 
 module.exports = { deepGet, isNothing, deepGetOrElse }

--- a/index.js
+++ b/index.js
@@ -14,35 +14,35 @@ const Nothing = { isNothing: true }
  */
 const get = (obj, key) => (obj && obj[key] !== null && obj[key] !== undefined) ? obj[key] : Nothing
 
-module.exports = {
-  /**
-   * Access deep properties on object going through the given path,
-   * returns {@link Nothing} if it is not possible to fetch the value
-   * @global
-   * @name deepGet
-   * @param { Object } obj Object to be accessed
-   * @param { String } path Path to be accessed separated by .
-   * @returns { * | Nothing } Final accessed property or nothing
-   */
-  deepGet: (obj, path) => path && path.split('.').reduce(get, obj),
+/**
+ * Access deep properties on object going through the given path,
+ * returns {@link Nothing} if it is not possible to fetch the value
+ * @global
+ * @name deepGet
+ * @param { Object } obj Object to be accessed
+ * @param { String } path Path to be accessed separated by .
+ * @returns { * | Nothing } Final accessed property or nothing
+ */
+const deepGet = (obj, path) => path && path.split('.').reduce(get, obj)
 
-  /**
-   * Access deep properties on object going through the given path
-   * If it would return a {@link Nothing}, it returns `fallback` instead
-   * @global
-   * @name deepGetOrElse
-   * @param { Object } obj Object to be accessed
-   * @param { String } path Path to be accessed separated by .
-   * @param { * } fallback the value to return if obj[path] is Nothing
-   */
-  deepGetOrElse: (obj, path, fallback) => isNothing(getAll(obj, path)) ? fallback : getAll(obj, path),
+/**
+ * Checks if x is Nothing
+ * @global
+ * @name isNothing
+ * @param { * } x Anything you want to test
+ * @returns { Boolean } whether it's equal or not
+ */
+const isNothing = (x) => x === Nothing
 
-  /**
-   * Checks if x is Nothing
-   * @global
-   * @name isNothing
-   * @param { * } x Anything you want to test
-   * @returns { Boolean } whether it's equal or not
-   */
-  isNothing: (x) => x === Nothing
-}
+/**
+ * Access deep properties on object going through the given path
+ * If it would return a {@link Nothing}, it returns `fallback` instead
+ * @global
+ * @name deepGetOrElse
+ * @param { Object } obj Object to be accessed
+ * @param { String } path Path to be accessed separated by .
+ * @param { * } fallback the value to return if obj[path] is Nothing
+ */
+deepGetOrElse = (obj, path, fallback) => isNothing(deepGet(obj, path)) ? fallback : deepGet(obj, path)
+
+module.exports = { deepGet, isNothing, deepGetOrElse }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "deep-getter",
-  "version": "0.0.0",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2296,12 +2296,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2316,17 +2318,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2443,7 +2448,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2455,6 +2461,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2469,6 +2476,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2476,12 +2484,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -2500,6 +2510,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2580,7 +2591,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2592,6 +2604,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2713,6 +2726,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "npm run lint && npm run test && npm run docs",
     "docs": "npx jsdoc2md *.js > ./docs/README.md",
     "lint": "eslint --ext .js ./",
+    "fix": "eslint --ext .js ./ --fix",
     "test": "jest"
   },
   "repository": {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -12,7 +12,7 @@ const mock = {
 
 describe('deepGet function', () => {
   it('should return the property value', () => {
-    expect(deepGet(mock, 'data.details.hasImage')).toBe(true)
+    expect(deepGet(mock, 'data.details.hasImage')).toEqual(mock.data.details.hasImage)
   })
 
   it('should return false in false property instead of Nothing', () => {
@@ -50,4 +50,8 @@ describe('failsafe environment', () => {
   it('should not break when accessing subsequent non existent keys', () => {
     expect(isNothing(deepGet(mock, 'data.error.error.error.error'))).toBe(true)
   })
+})
+
+describe('deepGetOrElse function', () => {
+  it('should return the ')
 })

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,4 +1,4 @@
-const { deepGet, isNothing } = require('../index')
+const { deepGet, deepGetOrElse, isNothing } = require('../index')
 const mock = {
   data: {
     colors: [ 'gray', 'blue' ],
@@ -16,7 +16,7 @@ describe('deepGet function', () => {
   })
 
   it('should return false in false property instead of Nothing', () => {
-    expect(deepGet(mock, 'data.details.falseProp')).toBe(false)
+    expect(deepGet(mock, 'data.details.falseProp')).toEqual(mock.data.details.falseProp)
   })
 
   it('should access array index in path', () => {
@@ -53,5 +53,19 @@ describe('failsafe environment', () => {
 })
 
 describe('deepGetOrElse function', () => {
-  it('should return the ')
+  it('should return truthy property value', () => {
+    expect(deepGetOrElse(mock, 'data.details.falseProp', false))
+      .toEqual(mock.data.details.falseProp)
+  })
+
+
+  it('should return falsy property value', () => {
+    expect(deepGetOrElse(mock, 'data.details.falseProp', true))
+      .toEqual(mock.data.details.falseProp)
+  })
+
+  it('should return fallback value', () => {
+    expect(deepGetOrElse(mock, 'data.details.nonexistent', 'fallbackValue'))
+      .toEqual('fallbackValue')
+  })
 })

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -58,7 +58,6 @@ describe('deepGetOrElse function', () => {
       .toEqual(mock.data.details.falseProp)
   })
 
-
   it('should return falsy property value', () => {
     expect(deepGetOrElse(mock, 'data.details.falseProp', true))
       .toEqual(mock.data.details.falseProp)


### PR DESCRIPTION
To avoid redundantly checking for nothing results you can now apply the fallback already at the `deepGetOrElse` function